### PR TITLE
Customize Media Session notifications

### DIFF
--- a/components/article.js
+++ b/components/article.js
@@ -7,18 +7,18 @@ export default ({ article }) => {
     <img alt="Article image" src={article.image} style={{ width: "100%" }} />
   );
 
-  const authors = _get(article, "author.0", "");
+  const publisher = _get(article, "publisher", "");
 
   const authorComponent =
-    _isEmpty(authors) || authors.includes("{{") ? null : (
+    _isEmpty(publisher) ? null : (
       <div style={{ textAlign: "center" }}>
         by{" "}
-        <span style={{ fontStyle: "italic" }}>{article.author.join(", ")}</span>
+        <span style={{ fontStyle: "italic" }}>{publisher}</span>
       </div>
     );
 
   const articleComponent = _isEmpty(article) ? null : (
-    <React.Fragment>
+    <>
       <h1 style={{ paddingTop: "1rem", textAlign: "center" }}>
         {article.title}
       </h1>
@@ -26,7 +26,7 @@ export default ({ article }) => {
       <p style={{ padding: "2rem 0", whiteSpace: "pre-wrap" }}>
         {article.text}
       </p>
-    </React.Fragment>
+    </>
   );
 
   return (

--- a/components/audio.js
+++ b/components/audio.js
@@ -9,6 +9,8 @@ class Audio extends React.Component {
 
   componentDidMount() {
     this.refs.audio.playbackRate = this.props.audioSpeed;
+
+    this.setMediaSession();
   }
 
   componentDidUpdate(prevProps) {
@@ -29,6 +31,25 @@ class Audio extends React.Component {
     return _get(this, "props.skipSeconds", this.DEFAULT_SKIP_SECONDS);
   };
 
+  setMediaSession() {
+    if ("mediaSession" in navigator) {
+      navigator.mediaSession.metadata = new MediaMetadata({
+        title: this.props.articleTitle,
+        artist: this.props.articlePublisher,
+        artwork: [{ src: this.props.articleImage }]
+      });
+
+      navigator.mediaSession.setActionHandler(
+        "seekbackward",
+        this.onBackSpeedButtonClick
+      );
+      navigator.mediaSession.setActionHandler(
+        "seekforward",
+        this.onForwardSpeedButtonClick
+      );
+    }
+  }
+
   render() {
     const skipSeconds = this.getSkipSeconds();
 
@@ -40,7 +61,11 @@ class Audio extends React.Component {
               Your browser does not support the <code>audio</code> element.
             </audio>
           </Col>
-          <Col className="xs-margin-bottom" md="4" style={{ textAlign: "center" }}>
+          <Col
+            className="xs-margin-bottom"
+            md="4"
+            style={{ textAlign: "center" }}
+          >
             <ButtonGroup>
               <Button color="info" onClick={this.onBackSpeedButtonClick}>
                 <i className="fas fa-undo" /> {skipSeconds}s
@@ -63,6 +88,12 @@ class Audio extends React.Component {
 }
 
 Audio.propTypes = {
+  articleImage: PropTypes.string,
+  articlePublisher: PropTypes.string,
+  articleTitle: PropTypes.string,
+  audioSpeed: PropTypes.number,
+  audioUrl: PropTypes.string.isRequired,
+  onAudioSpeedChange: PropTypes.func,
   skipSeconds: PropTypes.number
 };
 


### PR DESCRIPTION
# What's this do?

On mobile, this customizes the notification with buttons to jump back/forward by 10 seconds, as well as adds the article's header image to the notification.

#### Anything the reviewer(s) should know to review effectively?

- https://developers.google.com/web/updates/2017/02/media-session#customize_the_notification

# Screenshots (if applicable)

![Screenshot_20190311-121511](https://user-images.githubusercontent.com/586779/54139509-184a8c80-43f8-11e9-93cb-c2e499bfed38.png)

## Without a page refresh, but with a new article:
![Screenshot_20190311-121227](https://user-images.githubusercontent.com/586779/54139506-17195f80-43f8-11e9-9ab4-33d1ab141663.png)

## When no image is available:
![Screenshot_20190311-121327](https://user-images.githubusercontent.com/586779/54139504-14b70580-43f8-11e9-9386-2bc0ad82249f.png)

## On the lock screen:
![Screenshot_20190311-124419](https://user-images.githubusercontent.com/586779/54141235-aaa05f80-43fb-11e9-9d52-46b8bcc960a0.png)
